### PR TITLE
add arduino API

### DIFF
--- a/Adafruit_LIS3MDL.cpp
+++ b/Adafruit_LIS3MDL.cpp
@@ -527,6 +527,9 @@ int Adafruit_LIS3MDL::magneticFieldAvailable(void) {
 /**************************************************************************/
 /*!
     @brief Read magnetic data
+    @param x reference to x axis
+    @param y reference to y axis
+    @param z reference to z axis
     @returns 1 if success, 0 if not
 */
 int Adafruit_LIS3MDL::readMagneticField(float &x, float &y, float &z) {

--- a/Adafruit_LIS3MDL.cpp
+++ b/Adafruit_LIS3MDL.cpp
@@ -54,11 +54,6 @@ bool Adafruit_LIS3MDL::begin_I2C(uint8_t i2c_address, TwoWire *wire) {
     return false;
   }
 
-  busio = new Adafruit_BusIO_Register(i2c_dev, 0x0000);
-  if (!busio) {
-    return false;
-  }
-
   return _init();
 }
 
@@ -78,12 +73,6 @@ boolean Adafruit_LIS3MDL::begin_SPI(uint8_t cs_pin, SPIClass *theSPI) {
                                      theSPI);
   }
   if (!spi_dev->begin()) {
-    return false;
-  }
-
-  busio = new Adafruit_BusIO_Register(spi_dev, 0x0000,
-                                      AD8_HIGH_TOREAD_AD7_HIGH_TOINC);
-  if (!busio) {
     return false;
   }
 
@@ -108,12 +97,6 @@ bool Adafruit_LIS3MDL::begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
                                      SPI_MODE0);            // data mode
   }
   if (!spi_dev->begin()) {
-    return false;
-  }
-
-  busio = new Adafruit_BusIO_Register(spi_dev, 0x0000,
-                                      AD8_HIGH_TOREAD_AD7_HIGH_TOINC);
-  if (!busio) {
     return false;
   }
 
@@ -520,8 +503,9 @@ float Adafruit_LIS3MDL::magneticFieldSampleRate(void) {
     @returns 1 if available, 0 if not
 */
 int Adafruit_LIS3MDL::magneticFieldAvailable(void) {
-  busio->setAddress(LIS3MDL_REG_STATUS);
-  return (busio->read() & 0x08) ? 1 : 0;
+  Adafruit_BusIO_Register REG_STATUS = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, AD8_HIGH_TOREAD_AD7_HIGH_TOINC, LIS3MDL_REG_STATUS, 1);
+  return (REG_STATUS.read() & 0x08) ? 1 : 0;
 }
 
 /**************************************************************************/
@@ -535,9 +519,10 @@ int Adafruit_LIS3MDL::magneticFieldAvailable(void) {
 int Adafruit_LIS3MDL::readMagneticField(float &x, float &y, float &z) {
   int16_t data[3];
 
-  busio->setAddress(LIS3MDL_REG_OUT_X_L);
+  Adafruit_BusIO_Register XYZDataReg = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, AD8_HIGH_TOREAD_AD7_HIGH_TOINC, LIS3MDL_REG_OUT_X_L, 1);
 
-  if (!busio->read((uint8_t *)data, sizeof(data))) {
+  if (!XYZDataReg.read((uint8_t *)data, sizeof(data))) {
     x = y = z = NAN;
     return 0;
   }

--- a/Adafruit_LIS3MDL.cpp
+++ b/Adafruit_LIS3MDL.cpp
@@ -53,7 +53,6 @@ bool Adafruit_LIS3MDL::begin_I2C(uint8_t i2c_address, TwoWire *wire) {
   if (!i2c_dev->begin()) {
     return false;
   }
-
   return _init();
 }
 
@@ -75,7 +74,6 @@ boolean Adafruit_LIS3MDL::begin_SPI(uint8_t cs_pin, SPIClass *theSPI) {
   if (!spi_dev->begin()) {
     return false;
   }
-
   return _init();
 }
 
@@ -99,7 +97,6 @@ bool Adafruit_LIS3MDL::begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
   if (!spi_dev->begin()) {
     return false;
   }
-
   return _init();
 }
 
@@ -520,7 +517,7 @@ int Adafruit_LIS3MDL::readMagneticField(float &x, float &y, float &z) {
   int16_t data[3];
 
   Adafruit_BusIO_Register XYZDataReg = Adafruit_BusIO_Register(
-      i2c_dev, spi_dev, AD8_HIGH_TOREAD_AD7_HIGH_TOINC, LIS3MDL_REG_OUT_X_L, 1);
+      i2c_dev, spi_dev, AD8_HIGH_TOREAD_AD7_HIGH_TOINC, LIS3MDL_REG_OUT_X_L, 6);
 
   if (!XYZDataReg.read((uint8_t *)data, sizeof(data))) {
     x = y = z = NAN;

--- a/Adafruit_LIS3MDL.h
+++ b/Adafruit_LIS3MDL.h
@@ -23,6 +23,7 @@ I2C ADDRESS/BITS
 #define LIS3MDL_REG_CTRL_REG2 0x21 ///< Register address for control 2
 #define LIS3MDL_REG_CTRL_REG3 0x22 ///< Register address for control 3
 #define LIS3MDL_REG_CTRL_REG4 0x23 ///< Register address for control 3
+#define LIS3MDL_REG_STATUS 0x27    ///< Register address for status
 #define LIS3MDL_REG_OUT_X_L 0x28   ///< Register address for X axis lower byte
 #define LIS3MDL_REG_INT_CFG 0x30   ///< Interrupt configuration register
 #define LIS3MDL_REG_INT_THS_L 0x32 ///< Low byte of the irq threshold
@@ -96,6 +97,11 @@ public:
   bool getEvent(sensors_event_t *event);
   void getSensor(sensor_t *sensor);
 
+  // Arduino compatible API
+  int readMagneticField(float &x, float &y, float &z);
+  float magneticFieldSampleRate(void);
+  int magneticFieldAvailable(void);
+
   int16_t x,     ///< The last read X mag in raw units
       y,         ///< The last read Y mag in raw units
       z;         ///< The last read Z mag in raw units
@@ -108,6 +114,7 @@ private:
 
   Adafruit_I2CDevice *i2c_dev = NULL;
   Adafruit_SPIDevice *spi_dev = NULL;
+  Adafruit_BusIO_Register *busio = NULL;
 
   int32_t _sensorID;
 };

--- a/Adafruit_LIS3MDL.h
+++ b/Adafruit_LIS3MDL.h
@@ -114,7 +114,6 @@ private:
 
   Adafruit_I2CDevice *i2c_dev = NULL;
   Adafruit_SPIDevice *spi_dev = NULL;
-  Adafruit_BusIO_Register *busio = NULL;
 
   int32_t _sensorID;
 };


### PR DESCRIPTION
similar to https://github.com/adafruit/Adafruit_LSM6DS/pull/21, this PRs add compatible API for arduino library

```C
  int readMagneticField(float &x, float &y, float &z);
  float magneticFieldSampleRate(void);
  int magneticFieldAvailable(void);
```

PS: written fashion that requires adafruit/Adafruit_BusIO#46, therefore this is submitted as draft for now. Until the busio libraries release is indexed.