### PR TITLE
Improve sensor init

### DIFF
--- a/Adafruit_LIS3MDL.cpp
+++ b/Adafruit_LIS3MDL.cpp
@@ -127,9 +127,6 @@ bool Adafruit_LIS3MDL::_init(void) {
 
   reset();
 
-  // set high quality performance mode
-  setPerformanceMode(LIS3MDL_ULTRAHIGHMODE);
-
   // 155Hz default rate
   setDataRate(LIS3MDL_DATARATE_155_HZ);
 


### PR DESCRIPTION
Slightly improves default sensor initialization by removing double call to `setPerformanceMode` since `setDataRate(LES3MDL_DATARATE_155_HZ)` already calls `setPerformanceMode(LIS3MDL_ULTRAHIGHMODE)` internally:

https://github.com/adafruit/Adafruit_LIS3MDL/blob/64e685ba784c9741b5b101ca8ce509a101a8ff1b/Adafruit_LIS3MDL.cpp#L300-L304

This has no known limitations as it relies on existing built-in code, and as the change is only an internal change to `_init()` this will have no breaking changes to existing user code.